### PR TITLE
Use DeCLUTR-small as default model

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     `CUDA_DEVICE=0 MAX_LENGTH=384 uvicorn main:app`
     """
 
-    pretrained_model_name_or_path: str = "allenai/scibert_scivocab_uncased"
+    pretrained_model_name_or_path: str = "johngiorgi/declutr-small"
     batch_size: int = 64
     max_length: Optional[int] = None
     mean_pool: bool = True
@@ -111,7 +111,7 @@ def _encode(
 
     for name, tensor in inputs.items():
         inputs[name] = tensor.to(model.device)
-    sequence_output, _ = model(**inputs)
+    sequence_output, _ = model(**inputs, output_hidden_states=False)
 
     if mean_pool:
         embedding = torch.sum(


### PR DESCRIPTION
Switch default model to [DeCLUTR-small](https://huggingface.co/johngiorgi/declutr-small). This comes from our [recent work](https://github.com/JohnGiorgi/DeCLUTR). The benefits:

- Performance (how well it ranks articles) should be better. I ran some sanity checks and it was able to identify a COVID abstract as most similar to a COVID query (out of 1000 other non-COVID abstracts). But @jvwong it may be good to check performance if you have some kind of tests you were using?
- Speed of processing is improved (from ~13secs/1000 abstracts --> ~9secs/1000 abstracts).

All you need to do is restart the server and the model will be downloaded automatically.

> Just note, It was not trained on scientific articles specifically, but this is something I could look into for the future.

## Other changes

- :bug: Found two bugs that lead to totally wrong outputs. I should really write some unit tests (#14).