### PR TITLE
Make default model domain specific

### DIFF
--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -9,7 +9,7 @@ from transformers import AutoModel, AutoTokenizer, PreTrainedModel, PreTrainedTo
 
 from semantic_search.ncbi import uids_to_docs
 
-PRETRAINED_MODEL = "johngiorgi/declutr-small"
+PRETRAINED_MODEL = "johngiorgi/declutr-sci-base"
 
 UID = str
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,15 +1,15 @@
 import numpy as np
 from semantic_search import main
 from semantic_search.main import app_startup, encode
-from transformers import RobertaModel, RobertaTokenizer
+from transformers import PreTrainedModel, PreTrainedTokenizer
 
 
 class TestMain:
     app_startup()
 
     def test_setup_model_and_tokenizer(self) -> None:
-        assert isinstance(main.model.tokenizer, RobertaTokenizer)
-        assert isinstance(main.model.model, RobertaModel)
+        assert isinstance(main.model.tokenizer, PreTrainedTokenizer)
+        assert isinstance(main.model.model, PreTrainedModel)
 
     def test_encode(self, inputs):
         embeddings = encode(inputs)


### PR DESCRIPTION
# Overview

This PR changes the default model to a domain-specific one. Specifically, it is [AllenAI's SciBERT](https://huggingface.co/allenai/scibert_scivocab_uncased) model, after extended training on 2 million scientific papers with our DeCLUTR training process.

I evaluated 4 models on the [BIOESS dataset](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5870675/), which is I think is the best proxy for BioFactoids related article search. The relative ranking was:

declutr-sci-base > declutr-small (current model) > scibert > declutr-base.

## TODO

- [x] Confirm that [SciBERT NLI](https://huggingface.co/gsarti/scibert-nli) does not outperform declutr-sci-base, and if so, merge.

## Closes 

Closes #29.