### PR TITLE
query pop

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Type check with mypy
       run: |
-        mypy .
+        mypy . --cache-dir=/dev/null
     - name: Test with pytest
       run: |
         pytest tests --cov ./semantic_search --cov-report=xml --cov-config=./.coveragerc

--- a/README.md
+++ b/README.md
@@ -73,24 +73,20 @@ Once the server is running, you can make a POST request with:
                 "text": "High-fidelity promoter profiling reveals widespread alternative promoter usage and transposon-driven developmental gene expression. Many eukaryotic genes possess multiple alternative promoters with distinct expression specificities..."
             }
         ],
-        "top_k":3
+        "top_k":2
     }
     ```
 
-    The return value is a JSON representation of the `top_k` most similar documents (default: return all):
+    The return value is a JSON representation of the `top_k` most similar documents (default: return all, except the query itself):
 
     ```json
     [
         {
-            "uid": "9887103",
-            "score": 1.0
-        },
-        {
-            "uid": "30049242",
+            "uid": 30049242,
             "score": 0.6427373886108398
         },
         {
-            "uid": "22936248",
+            "uid": 22936248,
             "score": 0.49102723598480225
         }
     ]
@@ -104,7 +100,7 @@ Once the server is running, you can make a POST request with:
     {
         "query": "9887103",
         "documents": ["9887103", "30049242", "22936248"],
-        "top_k": 3
+        "top_k": 2
     }
     ```
 

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -106,7 +106,7 @@ async def query(query: Query) -> List[Dict[str, float]]:
         add_to_faiss_index(ids, embeddings, model.index)
 
     # Can't search for more items than exist in the index
-    top_k = min(model.index.ntotal, query.top_k) + 1
+    top_k = min(model.index.ntotal, query.top_k + 1)
 
     # Embed the query and perform the search
     query_embedding = encode(query.query.text).cpu().numpy()
@@ -117,8 +117,10 @@ async def query(query: Query) -> List[Dict[str, float]]:
 
     if int(query.query.uid) in (top_k_indicies):
         index = top_k_indicies.index(int(query.query.uid))
-        del top_k_indicies[index], top_k_scores[index]
+        del top_k_indicies[index] 
+        del top_k_scores[index]
     else:
-        del top_k_indicies[-1], top_k_scores[-1]
+        del top_k_indicies[-1]
+        del top_k_scores[-1]
 
     return [{"uid": uid, "score": score} for uid, score in zip(top_k_indicies, top_k_scores)]

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -106,7 +106,7 @@ async def query(query: Query) -> List[Dict[str, float]]:
         add_to_faiss_index(ids, embeddings, model.index)
 
     # Can't search for more items than exist in the index
-    top_k = min(model.index.ntotal, query.top_k)
+    top_k = min(model.index.ntotal, query.top_k)+1
 
     # Embed the query and perform the search
     query_embedding = encode(query.query.text).cpu().numpy()
@@ -114,5 +114,13 @@ async def query(query: Query) -> List[Dict[str, float]]:
 
     top_k_indicies = top_k_indicies.reshape(-1).tolist()
     top_k_scores = top_k_scores.reshape(-1).tolist()
+
+    if (query.query.uid) in top_k_indicies:
+        index = top_k_indicies.index(query.query.uid)
+        print(index)
+        
+    print(query.query.uid)
+    print (top_k_indicies)
+    print (top_k_scores)
 
     return [{"uid": uid, "score": score} for uid, score in zip(top_k_indicies, top_k_scores)]

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -115,7 +115,7 @@ async def query(query: Query) -> List[Dict[str, float]]:
     top_k_indicies = top_k_indicies.reshape(-1).tolist()
     top_k_scores = top_k_scores.reshape(-1).tolist()
 
-    if int(query.query.uid) in (top_k_indicies):
+    if int(query.query.uid) in top_k_indicies:
         index = top_k_indicies.index(int(query.query.uid))
         del top_k_indicies[index], top_k_scores[index]
     else:

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -106,7 +106,7 @@ async def query(query: Query) -> List[Dict[str, float]]:
         add_to_faiss_index(ids, embeddings, model.index)
 
     # Can't search for more items than exist in the index
-    top_k = min(model.index.ntotal, query.top_k)+1
+    top_k = min(model.index.ntotal, query.top_k) + 1
 
     # Embed the query and perform the search
     query_embedding = encode(query.query.text).cpu().numpy()
@@ -115,12 +115,10 @@ async def query(query: Query) -> List[Dict[str, float]]:
     top_k_indicies = top_k_indicies.reshape(-1).tolist()
     top_k_scores = top_k_scores.reshape(-1).tolist()
 
-    if (query.query.uid) in top_k_indicies:
-        index = top_k_indicies.index(query.query.uid)
-        print(index)
-        
-    print(query.query.uid)
-    print (top_k_indicies)
-    print (top_k_scores)
+    if int(query.query.uid) in (top_k_indicies):
+        index = top_k_indicies.index(int(query.query.uid))
+        del top_k_indicies[index], top_k_scores[index]
+    else:
+        del top_k_indicies[-1], top_k_scores[-1]
 
     return [{"uid": uid, "score": score} for uid, score in zip(top_k_indicies, top_k_scores)]

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -117,10 +117,8 @@ async def query(query: Query) -> List[Dict[str, float]]:
 
     if int(query.query.uid) in (top_k_indicies):
         index = top_k_indicies.index(int(query.query.uid))
-        del top_k_indicies[index] 
-        del top_k_scores[index]
+        del top_k_indicies[index], top_k_scores[index]
     else:
-        del top_k_indicies[-1]
-        del top_k_scores[-1]
+        del top_k_indicies[-1], top_k_scores[-1]
 
     return [{"uid": uid, "score": score} for uid, score in zip(top_k_indicies, top_k_scores)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -16,7 +16,7 @@ def inputs() -> List[str]:
 
 
 @pytest.fixture(scope="module")
-def dummy_request_with_text() -> str:
+def dummy_request_with_text() -> Tuple[str, Dict[str, Any]]:
     request = {
         "query": {
             "uid": "9887103",
@@ -44,7 +44,7 @@ def dummy_request_with_text() -> str:
 
 
 @pytest.fixture(scope="module")
-def dummy_request_with_uids() -> str:
+def dummy_request_with_uids() -> Tuple[str, Dict[str, Any]]:
     request = {
         "query": "9887103",
         "documents": ["9887103", "30049242", "22936248"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,9 @@ def dummy_request_with_text() -> str:
         ],
         "top_k": 3,
     }
-    return json.dumps(request)
+    # We don't actually test scores, so use a dummy value of -1
+    response = [{"uid": 30049242, "score": -1}, {"uid": 22936248, "score": -1}]
+    return json.dumps(request), response
 
 
 @pytest.fixture(scope="module")
@@ -48,7 +50,9 @@ def dummy_request_with_uids() -> str:
         "documents": ["9887103", "30049242", "22936248"],
         "top_k": 3,
     }
-    return json.dumps(request)
+    # We don't actually test scores, so use a dummy value of -1
+    response = [{"uid": 30049242, "score": -1}, {"uid": 22936248, "score": -1}]
+    return json.dumps(request), response
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 import json
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 
 import pytest
+
+Request = Tuple[str, List[Dict[str, int]]]
 
 
 @pytest.fixture(scope="module")
@@ -16,7 +18,7 @@ def inputs() -> List[str]:
 
 
 @pytest.fixture(scope="module")
-def dummy_request_with_text() -> Tuple[str, Dict[str, Any]]:
+def dummy_request_with_text() -> Request:
     request = {
         "query": {
             "uid": "9887103",
@@ -44,7 +46,7 @@ def dummy_request_with_text() -> Tuple[str, Dict[str, Any]]:
 
 
 @pytest.fixture(scope="module")
-def dummy_request_with_uids() -> Tuple[str, Dict[str, Any]]:
+def dummy_request_with_uids() -> Request:
     request = {
         "query": "9887103",
         "documents": ["9887103", "30049242", "22936248"],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,21 +30,17 @@ class TestMain:
 
     def test_query(self, dummy_requests: str) -> None:
         # dummy_requests fixutre returns list of all possible request types
-        for request in dummy_requests:
+        for request, expected_response in dummy_requests:
             # Check that we can make a POST request with properly formatted payload
-            response = client.post("/", request)
-            assert response.status_code == 200
+            actual_response = client.post("/", request)
+            assert actual_response.status_code == 200
 
             # Check that the returned UIDs and scores are as expected
-            expected_uids = [
-                int(item["uid"]) if isinstance(item, dict) else int(item)
-                for item in json.loads(request)["documents"]
-            ]
-            actual_uids = [item["uid"] for item in response.json()]
-            actual_scores = [item["score"] for item in response.json()]
-            del expected_uids[0]
+            expected_uids = [item["uid"] for item in expected_response]
+            actual_uids = [item["uid"] for item in actual_response.json()]
+            actual_scores = [item["score"] for item in actual_response.json()]
             assert len(expected_uids) == len(actual_uids)
-            assert set(actual_uids)  == set(expected_uids)
+            assert set(actual_uids) == set(expected_uids)
             assert all(0 <= score <= 1 for score in actual_scores)
 
     @settings(deadline=None)
@@ -54,7 +50,7 @@ class TestMain:
         # once we solve the issue that causes requests with IDs to keep fetching the text
         # even if the ids have been indexed.
         dummy_requests = [dummy_request_with_text]
-        for request in dummy_requests:
+        for request, _ in dummy_requests:
             request = json.loads(request)
             request["top_k"] = bad_top_k  # type: ignore
             request = json.dumps(request)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import json
+from typing import Dict, List, Tuple
 
 import hypothesis.strategies as st
 import numpy as np
@@ -9,6 +10,8 @@ from semantic_search.main import app, app_startup, encode
 from transformers import PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerFast
 
 client = TestClient(app)
+
+Request = Tuple[str, List[Dict[str, int]]]
 
 
 class TestMain:
@@ -28,15 +31,15 @@ class TestMain:
         assert isinstance(main.model.tokenizer, (PreTrainedTokenizer, PreTrainedTokenizerFast))
         assert isinstance(main.model.model, PreTrainedModel)
 
-    def test_query(self, dummy_requests: str) -> None:
+    def test_query(self, dummy_requests: Request) -> None:
         # dummy_requests fixutre returns list of all possible request types
-        for request, expected_response in dummy_requests:
+        for request, expected_response in dummy_requests:  # type: ignore
             # Check that we can make a POST request with properly formatted payload
-            actual_response = client.post("/", request)
+            actual_response = client.post("/", request)  # type: ignore
             assert actual_response.status_code == 200
 
             # Check that the returned UIDs and scores are as expected
-            expected_uids = [item["uid"] for item in expected_response]
+            expected_uids = [item["uid"] for item in expected_response]  # type: ignore
             actual_uids = [item["uid"] for item in actual_response.json()]
             actual_scores = [item["score"] for item in actual_response.json()]
             assert len(expected_uids) == len(actual_uids)
@@ -45,7 +48,7 @@ class TestMain:
 
     @settings(deadline=None)
     @given(bad_top_k=st.integers(max_value=0))
-    def test_top_k_gt_zero(self, dummy_request_with_text: str, bad_top_k: int) -> None:
+    def test_top_k_gt_zero(self, dummy_request_with_text: Request, bad_top_k: int) -> None:
         # TODO: We can change this back to just using the dummy_requests fixture
         # once we solve the issue that causes requests with IDs to keep fetching the text
         # even if the ids have been indexed.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -42,8 +42,9 @@ class TestMain:
             ]
             actual_uids = [item["uid"] for item in response.json()]
             actual_scores = [item["score"] for item in response.json()]
+            del expected_uids[0]
             assert len(expected_uids) == len(actual_uids)
-            assert set(actual_uids) == set(expected_uids)
+            assert set(actual_uids)  == set(expected_uids)
             assert all(0 <= score <= 1 for score in actual_scores)
 
     @settings(deadline=None)


### PR DESCRIPTION
Hey, I'm trying to get the query to pop from the final list. Over here you can see that I set an if statement where it states 
`if (query.query.uid) in top_k_indicies:`

'query.query.uid` is `9887103` and `top_k_indicies` is `[9887103, 30049242, 22936248, 33535164]`
 (It has extra PMID's because I added them)

The question is regarding the first index because `9887103` is present in the list, so it should go into the if statement. However, this is not the case. Could you possibly tell me why this is happening?

https://github.com/PathwayCommons/semantic-search/blob/1598015e545862e99ca7b1fbcdf2f22714de6a1e/semantic_search/main.py#L117-L125

I'm printing a few things there just for debugging purposes. You will be able to that the query is actually in the list. This is the output of all the print statements:

![image](https://user-images.githubusercontent.com/57552053/110167076-3a96fb00-7dc3-11eb-9804-849a8cc8bbe7.png)
