### PR TITLE
Add response model

### DIFF
--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -1,5 +1,5 @@
 from operator import itemgetter
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import List, Optional, Tuple, Union, cast
 
 import faiss
 import torch
@@ -13,7 +13,7 @@ from semantic_search.common.util import (
     setup_faiss_index,
     setup_model_and_tokenizer,
 )
-from semantic_search.schemas import Model, Query
+from semantic_search.schemas import Model, Query, Response
 
 app = FastAPI(
     title="Scientific Semantic Search",
@@ -83,8 +83,8 @@ def app_startup():
     model.index = setup_faiss_index(embedding_dim)
 
 
-@app.post("/")
-async def query(query: Query) -> List[Dict[str, float]]:
+@app.post("/", response_model=List[Response])
+async def query(query: Query):
     ids = [int(doc.uid) for doc in query.documents]
     texts = [document.text for document in query.documents]
 
@@ -121,4 +121,5 @@ async def query(query: Query) -> List[Dict[str, float]]:
     else:
         del top_k_indicies[-1], top_k_scores[-1]
 
-    return [{"uid": uid, "score": score} for uid, score in zip(top_k_indicies, top_k_scores)]
+    response = [Response(uid=uid, score=score) for uid, score in zip(top_k_indicies, top_k_scores)]
+    return response

--- a/semantic_search/schemas.py
+++ b/semantic_search/schemas.py
@@ -11,15 +11,6 @@ UID = str
 # See: https://fastapi.tiangolo.com/tutorial/body/ for more details on creating a Request Body.
 
 
-class Model(BaseModel):
-    tokenizer: PreTrainedModel = None
-    model: PreTrainedTokenizer = None
-    index: faiss.Index = None
-
-    class Config:
-        arbitrary_types_allowed = True
-
-
 class Document(BaseModel):
     uid: UID
     text: str
@@ -48,3 +39,17 @@ class Query(BaseModel):
         if not v > 0:
             raise ValueError(f"top_k must be greater than 0, got {v}")
         return v
+
+
+class Model(BaseModel):
+    tokenizer: PreTrainedModel = None
+    model: PreTrainedTokenizer = None
+    index: faiss.Index = None
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class Response(BaseModel):
+    uid: UID
+    score: float

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import json
-from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple, Any
 
 import pytest
 
-Request = Tuple[str, List[Dict[str, int]]]
+Request = Tuple[str, List[Dict[str, Any]]]
 
 
 @pytest.fixture(scope="module")
@@ -41,7 +41,7 @@ def dummy_request_with_text() -> Request:
         "top_k": 3,
     }
     # We don't actually test scores, so use a dummy value of -1
-    response = [{"uid": 30049242, "score": -1}, {"uid": 22936248, "score": -1}]
+    response = [{"uid": "30049242", "score": -1}, {"uid": "22936248", "score": -1}]
     return json.dumps(request), response
 
 
@@ -53,7 +53,7 @@ def dummy_request_with_uids() -> Request:
         "top_k": 3,
     }
     # We don't actually test scores, so use a dummy value of -1
-    response = [{"uid": 30049242, "score": -1}, {"uid": 22936248, "score": -1}]
+    response = [{"uid": "30049242", "score": -1}, {"uid": "22936248", "score": -1}]
     return json.dumps(request), response
 
 


### PR DESCRIPTION
# Overview

This PR formalizes our APIs response by adding a [Response Model](https://fastapi.tiangolo.com/tutorial/response-model/#response-model-encoding-parameters). Ours is very simple:

```python
class Response(BaseModel):
    uid: UID
    score: float
```

Which we specify like so

```python
@app.post("/", response_model=List[Response])
async def query(query: Query):
```

This is mainly cosmetic but will cause more informative errors if you try to return a response that doesn't look like this. It also causes the documentation to auto-populate

![image](https://user-images.githubusercontent.com/8917831/110831774-93a1db80-8268-11eb-9b28-b8d5cc5c98e0.png)

Functionally, the code should work the same as before.