### PR TITLE
Replace top k validator with field

### DIFF
--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -1,7 +1,7 @@
 import io
 import os
 from pathlib import Path
-from typing import Any, Collection, Dict, List
+from typing import Any, Dict, List, Generator
 import logging
 import json
 import time
@@ -73,7 +73,7 @@ def _parse_medline(text: str) -> List[dict]:
     return medline_records
 
 
-def _get_eutil_records(eutil: str, id: List[str], **opts) -> dict:
+def _get_eutil_records(eutil: str, id: List[str], **opts) -> List[Dict[Any, Any]]:
     """Call one of the NCBI EUTILITIES and returns data as Python objects."""
     eutils_params = {
         "db": "pubmed",
@@ -93,7 +93,7 @@ def _get_eutil_records(eutil: str, id: List[str], **opts) -> dict:
     return _parse_medline(eutilResponse.text)
 
 
-def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, Collection[Any]]]:
+def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
     """Return a list Documents given a list of Medline records
     See https://www.nlm.nih.gov/bsd/mms/medlineelements.html
     """
@@ -111,7 +111,7 @@ def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, Collection
 
 
 # -- Public methods --
-def uids_to_docs(uids: List[str]) -> List[Dict[str, Collection[Any]]]:
+def uids_to_docs(uids: List[str]) -> Generator[List[Dict[str, str]], None, None]:
     """Return uid, and text (i.e. title + abstract) given a PubMed uid"""
     num_uids = len(uids)
     num_queries = num_uids // MAX_EFETCH_RETMAX + 1

--- a/semantic_search/schemas.py
+++ b/semantic_search/schemas.py
@@ -1,7 +1,7 @@
 from typing import List
 
 import faiss
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, Field
 from transformers import PreTrainedModel, PreTrainedTokenizer
 
 from semantic_search.ncbi import uids_to_docs
@@ -19,7 +19,7 @@ class Document(BaseModel):
 class Query(BaseModel):
     query: Document
     documents: List[Document] = []
-    top_k: int = 10
+    top_k: int = Field(10, gt=0, description="top_k must be greater than 0")
 
     @validator("query", "documents", pre=True)
     def normalize_document(cls, v, field):
@@ -36,12 +36,6 @@ class Query(BaseModel):
             else:
                 normalized_docs.append(doc)
         return normalized_docs[0] if field.name == "query" else normalized_docs
-
-    @validator("top_k")
-    def top_k_must_be_gt_zero(cls, v):
-        if not v > 0:
-            raise ValueError(f"top_k must be greater than 0, got {v}")
-        return v
 
 
 class Model(BaseModel):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,9 @@
-import json
 from typing import Dict, List, Tuple
 
-import hypothesis.strategies as st
+
 import numpy as np
 from fastapi.testclient import TestClient
-from hypothesis import given, settings
+
 from semantic_search import main
 from semantic_search.main import app, app_startup, encode
 from transformers import PreTrainedModel, PreTrainedTokenizer, PreTrainedTokenizerFast
@@ -45,17 +44,3 @@ class TestMain:
             assert len(expected_uids) == len(actual_uids)
             assert set(actual_uids) == set(expected_uids)
             assert all(0 <= score <= 1 for score in actual_scores)
-
-    @settings(deadline=None)
-    @given(bad_top_k=st.integers(max_value=0))
-    def test_top_k_gt_zero(self, dummy_request_with_text: Request, bad_top_k: int) -> None:
-        # TODO: We can change this back to just using the dummy_requests fixture
-        # once we solve the issue that causes requests with IDs to keep fetching the text
-        # even if the ids have been indexed.
-        dummy_requests = [dummy_request_with_text]
-        for request, _ in dummy_requests:
-            request = json.loads(request)
-            request["top_k"] = bad_top_k  # type: ignore
-            request = json.dumps(request)
-            response = client.post("/", request)
-            assert response.status_code == 422


### PR DESCRIPTION
I realized that for simple checking of arguments in our schemas, we can use the pydantics `Field`, rather than the its `validator` decorator. This really simplifies things and leads to fewer tests that we have to write. It basically looks like this:

```python
class Query(BaseModel):
    query: Document
    documents: List[Document] = []
    top_k: int = Field(10, gt=0, description="top_k must be greater than 0")
```

which causes the web service to return a 422 if a `top_k` is ever passed that is less than 1.

---

Also fixes a bunch of type hints in `ncbi.py`