### PR TITLE
Update schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,64 +49,48 @@ To provide arguments to the server, pass them as environment variables, e.g.:
 CUDA_DEVICE=0 MAX_LENGTH=384 uvicorn semantic_search.main:app
 ```
 
-Once the server is running, you can make a POST request with:
+Once the server is running, you can make a POST request with `JSON` body. E.g.
 
-1. JSON body that is self-contained. Provide the text in `query` and text in `documents` to search against. Sample JSON request:
-
-    ```json
-    {
-        "query": {
-            "uid":"9887103",
+```json
+{
+    "query": {
+        "uid":"9887103",
+        "text": "The Drosophila activin receptor baboon signals through dSmad2 and controls cell proliferation but not patterning during larval development. The TGF-beta superfamily of growth and differentiation factors, including TGF-beta, Activins and bone morphogenetic proteins (BMPs) play critical roles in regulating the development of many organisms..."
+    },
+    "documents":[
+        {
+            "uid": "9887103",
             "text": "The Drosophila activin receptor baboon signals through dSmad2 and controls cell proliferation but not patterning during larval development. The TGF-beta superfamily of growth and differentiation factors, including TGF-beta, Activins and bone morphogenetic proteins (BMPs) play critical roles in regulating the development of many organisms..."
         },
-        "documents":[
-            {
-                "uid": "9887103",
-                "text": "The Drosophila activin receptor baboon signals through dSmad2 and controls cell proliferation but not patterning during larval development. The TGF-beta superfamily of growth and differentiation factors, including TGF-beta, Activins and bone morphogenetic proteins (BMPs) play critical roles in regulating the development of many organisms..."
-            },
-            {
-                "uid": "30049242",
-                "text": "Transcriptional up-regulation of the TGF-β intracellular signaling transducer Mad of Drosophila larvae in response to parasitic nematode infection. The common fruit fly Drosophila melanogaster is an exceptional model for dissecting innate immunity..."
-            },
-            {
-                "uid": "22936248",
-                "text": "High-fidelity promoter profiling reveals widespread alternative promoter usage and transposon-driven developmental gene expression. Many eukaryotic genes possess multiple alternative promoters with distinct expression specificities..."
-            }
-        ],
-        "top_k":2
-    }
-    ```
-
-    The return value is a JSON representation of the `top_k` most similar documents (default: return all, except the query itself):
-
-    ```json
-    [
         {
-            "uid": 30049242,
-            "score": 0.6427373886108398
+            "uid": "30049242",
+            "text": "Transcriptional up-regulation of the TGF-β intracellular signaling transducer Mad of Drosophila larvae in response to parasitic nematode infection. The common fruit fly Drosophila melanogaster is an exceptional model for dissecting innate immunity..."
         },
         {
-            "uid": 22936248,
-            "score": 0.49102723598480225
+            "uid": "22936248",
+            "text": "High-fidelity promoter profiling reveals widespread alternative promoter usage and transposon-driven developmental gene expression. Many eukaryotic genes possess multiple alternative promoters with distinct expression specificities..."
         }
-    ]
-    ```
+    ],
+    "top_k":2
+}
+```
 
-    - NB: In this case, each `uid` in `documents` should be unique, but otherwise have no meaning.
+The return value is a JSON representation of the `top_k` most similar documents (defaults to 10):
 
-2. JSON body that references PubMed article uids. Sample JSON request:
-
-    ```json
+```json
+[
     {
-        "query": "9887103",
-        "documents": ["9887103", "30049242", "22936248"],
-        "top_k": 2
+        "uid": 30049242,
+        "score": 0.6427373886108398
+    },
+    {
+        "uid": 22936248,
+        "score": 0.49102723598480225
     }
-    ```
+]
+```
 
-    - Notes:
-      - For each Document element, the text consists of the `ArticleTitle` appended to `Abstract` for that PubMed article. See [pubmed DTD](https://dtd.nlm.nih.gov/ncbi/pubmed/doc/out/180101/index.html)
-      - JSON body may consist of either objects (as in Case 1) or PMID strings for `query` and elements of `documents`. However, the elements of `documents` must either be all be a single type.
+If `"text"` is not provided, we assume `"uid"`s are valid PMIDs and fetch the title and abstract text before embedding, indexing and searching.
 
 ### Running via Docker
 

--- a/semantic_search/common/util.py
+++ b/semantic_search/common/util.py
@@ -123,4 +123,4 @@ def normalize_documents(pmids: List[str]) -> str:
     normalized_docs = []
     for doc in pmids:
         normalized_docs.append(Document(**list(uids_to_docs([doc]))[0][0]))
-    return normalized_docs[0].text
+    return normalized_docs[0].text  # type: ignore

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -101,6 +101,9 @@ def index(request: Request):
 
 @app.post("/search", tags=["Search"], response_model=List[TopMatch])
 async def search(search: Search):
+    """Returns the `top_k` most similar documents to `query` from the provided list of `documents`
+    and the index.
+    """
     ids = [int(doc.uid) for doc in search.documents]
     texts = [document.text for document in search.documents]
 

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -1,9 +1,11 @@
+from datetime import datetime
+from http import HTTPStatus
 from operator import itemgetter
 from typing import List, Optional, Tuple, Union, cast
 
 import faiss
 import torch
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from pydantic import BaseSettings
 
 from semantic_search import __version__
@@ -14,7 +16,7 @@ from semantic_search.common.util import (
     setup_model_and_tokenizer,
     normalize_documents,
 )
-from semantic_search.schemas import Model, Query, Response
+from semantic_search.schemas import Model, Search, TopMatch
 
 app = FastAPI(
     title="Scientific Semantic Search",
@@ -84,23 +86,31 @@ def app_startup():
     model.index = setup_faiss_index(embedding_dim)
 
 
-@app.post("/", response_model=List[Response])
-async def query(query: Query):
-    """Returns the `search.top_k` most similar documents to the query (`search.query`) from the
-    provided list of documents (`search.documents`) and the index (`model.index`). Note that the
-    effective `top_k` might be less than requested depending on the number of unique items in
-    `search.documents` and `model.index`.
-    """
-    ids = [int(doc.uid) for doc in query.documents]
-    texts = [document.text for document in query.documents]
+@app.get("/", tags=["General"])
+def index(request: Request):
+    """Health check."""
+    response = {
+        "message": HTTPStatus.OK.phrase,
+        "method": request.method,
+        "status-code": HTTPStatus.OK,
+        "timestamp": datetime.now().isoformat(),
+        "url": request.url._url,
+    }
+    return response
+
+
+@app.post("/search", tags=["Search"], response_model=List[TopMatch])
+async def search(search: Search):
+    ids = [int(doc.uid) for doc in search.documents]
+    texts = [document.text for document in search.documents]
 
     # Only add items to the index if they do not already exist.
     # See: https://github.com/facebookresearch/faiss/issues/859
     # To do this, we first determine which of the incoming ids do not exist in the index
     indexed_ids = set(faiss.vector_to_array(model.index.id_map).tolist())
 
-    if query.query.text is None and query.query.uid not in indexed_ids:
-        query.query.text = normalize_documents([query.query.uid])
+    if search.query.text is None and search.query.uid not in indexed_ids:
+        search.query.text = normalize_documents([search.query.uid])
 
     for i, (id_, text) in enumerate(zip(ids, texts)):
         if text is None and id_ not in indexed_ids:
@@ -110,20 +120,21 @@ async def query(query: Query):
     to_embed = [(id_, text) for id_, text in zip(ids, texts) if id_ not in indexed_ids]
     if to_embed:
         ids, texts = zip(*to_embed)  # type: ignore
-        embeddings = encode(texts).cpu().numpy()
+        embeddings = encode(texts).cpu().numpy()  # type: ignore
         add_to_faiss_index(ids, embeddings, model.index)
 
     # Can't search for more items than exist in the index
-    top_k = min(model.index.ntotal, query.top_k)
+    top_k = min(model.index.ntotal, search.top_k)
     # Embed the query and perform the search
-    query_embedding = encode(query.query.text).cpu().numpy()
+    query_embedding = encode(search.query.text).cpu().numpy()  # type: ignore
     top_k_scores, top_k_indicies = model.index.search(query_embedding, top_k)
 
     top_k_indicies = top_k_indicies.reshape(-1).tolist()
     top_k_scores = top_k_scores.reshape(-1).tolist()
-    if int(query.query.uid) in top_k_indicies:
-        index = top_k_indicies.index(int(query.query.uid))
+
+    if int(search.query.uid) in top_k_indicies:
+        index = top_k_indicies.index(int(search.query.uid))
         del top_k_indicies[index], top_k_scores[index]
 
-    response = [Response(uid=uid, score=score) for uid, score in zip(top_k_indicies, top_k_scores)]
+    response = [TopMatch(uid=uid, score=score) for uid, score in zip(top_k_indicies, top_k_scores)]
     return response

--- a/semantic_search/schemas.py
+++ b/semantic_search/schemas.py
@@ -1,8 +1,11 @@
 from typing import List, Optional
 
 import faiss
-from pydantic import BaseModel, Field
+
+from pydantic import BaseModel, Field, validator
 from transformers import PreTrainedModel, PreTrainedTokenizer
+
+from semantic_search.ncbi import uids_to_docs
 
 UID = str
 
@@ -14,10 +17,56 @@ class Document(BaseModel):
     text: Optional[str] = None
 
 
-class Query(BaseModel):
+class Search(BaseModel):
     query: Document
-    documents: List[Document] = []
+    documents: List[Document]
     top_k: int = Field(10, gt=0, description="top_k must be greater than 0")
+
+    @validator("query", "documents", pre=True)
+    def normalize_document(cls, v, field):
+        if field.name == "query":
+            v = [v]
+
+        normalized_docs = []
+        for doc in v:
+            if isinstance(doc, UID):
+                # uids_to_docs expects a list of strings and yields a list of dictionaries. We
+                # convert the generator to a list, and then index its first element, and then
+                # unpack the dictionary and pass its contents as keyword arguments to Document.
+                normalized_docs.append(Document(**list(uids_to_docs([doc]))[0][0]))
+            else:
+                normalized_docs.append(doc)
+        return normalized_docs[0] if field.name == "query" else normalized_docs
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "query": {
+                    "uid": "0",
+                    "text": "It has recently been shown that Craf is essential for Kras G12D-induced NSCLC.",
+                },
+                "documents": [
+                    {
+                        "uid": "1",
+                        "text": "Craf is essential for the onset of Kras-driven non-small cell lung cancer.",
+                    },
+                    {
+                        "uid": "2",
+                        "text": "Tumorigenesis is a multistage process that involves multiple cell types.",
+                    },
+                    {
+                        "uid": "3",
+                        "text": "Only concomitant ablation of ERK1 and ERK2 impairs tumor growth.",
+                    },
+                ],
+                "top_k": 3,
+            }
+        }
+
+
+class TopMatch(BaseModel):
+    uid: UID
+    score: float
 
 
 class Model(BaseModel):
@@ -27,8 +76,3 @@ class Model(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
-
-
-class Response(BaseModel):
-    uid: UID
-    score: float

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def inputs() -> List[str]:
 
 
 @pytest.fixture(scope="module")
-def dummy_request_with_text() -> Request:
+def dummy_request_with_test() -> Request:
     request = {
         "query": {
             "uid": "9887103",
@@ -43,20 +43,3 @@ def dummy_request_with_text() -> Request:
     # We don't actually test scores, so use a dummy value of -1
     response = [{"uid": "30049242", "score": -1}, {"uid": "22936248", "score": -1}]
     return json.dumps(request), response
-
-
-@pytest.fixture(scope="module")
-def dummy_request_with_uids() -> Request:
-    request = {
-        "query": "9887103",
-        "documents": ["9887103", "30049242", "22936248"],
-        "top_k": 3,
-    }
-    # We don't actually test scores, so use a dummy value of -1
-    response = [{"uid": "30049242", "score": -1}, {"uid": "22936248", "score": -1}]
-    return json.dumps(request), response
-
-
-@pytest.fixture(scope="module")
-def dummy_requests(dummy_request_with_text, dummy_request_with_uids) -> List[str]:
-    return [dummy_request_with_text, dummy_request_with_uids]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -30,17 +30,21 @@ class TestMain:
         assert isinstance(main.model.tokenizer, (PreTrainedTokenizer, PreTrainedTokenizerFast))
         assert isinstance(main.model.model, PreTrainedModel)
 
-    def test_query(self, dummy_requests: Request) -> None:
-        # dummy_requests fixutre returns list of all possible request types
-        for request, expected_response in dummy_requests:  # type: ignore
-            # Check that we can make a POST request with properly formatted payload
-            actual_response = client.post("/", request)  # type: ignore
-            assert actual_response.status_code == 200
+    def test_index(self) -> None:
+        response = client.get("/")
+        assert response.status_code == 200
+        assert response.json()["message"] == "OK"
 
-            # Check that the returned UIDs and scores are as expected
-            expected_uids = [item["uid"] for item in expected_response]  # type: ignore
-            actual_uids = [item["uid"] for item in actual_response.json()]
-            actual_scores = [item["score"] for item in actual_response.json()]
-            assert len(expected_uids) == len(actual_uids)
-            assert set(actual_uids) == set(expected_uids)
-            assert all(0 <= score <= 1 for score in actual_scores)
+    def test_search_with_text(self, dummy_request_with_test: Request) -> None:
+        request, expected_response = dummy_request_with_test
+        # Check that we can make a POST request with properly formatted payload
+        actual_response = client.post("/search", request)
+        assert actual_response.status_code == 200
+
+        # Check that the returned UIDs and scores are as expected
+        expected_uids = [item["uid"] for item in expected_response]  # type: ignore
+        actual_uids = [item["uid"] for item in actual_response.json()]
+        actual_scores = [item["score"] for item in actual_response.json()]
+        assert len(expected_uids) == len(actual_uids)
+        assert set(actual_uids) == set(expected_uids)
+        assert all(0 <= score <= 1 for score in actual_scores)


### PR DESCRIPTION
# Overview

This PR addresses most of the points in #65. Namely:

- The route `"/"` is now used as a health check. It will return a status code, message, and other data if a get request is successfully completed.
- The route `"/search"` is now used in place of the old route, `"/"`.

I also made some other, QOL improvements:

- Rename the `Response` schema to `TopMatch`. This is more informative and doesn't overload the `Response` object from `FastAPI`.
- Group the documentation for endpoints under `"General"` and `"Search"`.
- Rename the `Query` object to `Search`. I find this more readable (`query.query` was weird)
- I added an example POST request to the documentation. If you navigate to `"/docs"`, it is prepopulated and you can execute it in the browser.