### PR TITLE
Top k issue

### DIFF
--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -85,14 +85,13 @@ def app_startup():
 
 @app.post("/", response_model=List[Response])
 async def query(query: Query):
+    """Returns the `search.top_k` most similar documents to the query (`search.query`) from the
+    provided list of documents (`search.documents`) and the index (`model.index`). Note that the
+    effective `top_k` might be less than requested depending on the number of unique items in
+    `search.documents` and `model.index`.
+    """
     ids = [int(doc.uid) for doc in query.documents]
     texts = [document.text for document in query.documents]
-
-    # # Ensure that the query is not in the index when we search.
-    # query_id = np.asarray(int(query.query.uid)).reshape(
-    #     1,
-    # )
-    # model.index.remove_ids(query_id)
 
     # Only add items to the index if they do not already exist.
     # See: https://github.com/facebookresearch/faiss/issues/859

--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -106,20 +106,16 @@ async def query(query: Query):
         add_to_faiss_index(ids, embeddings, model.index)
 
     # Can't search for more items than exist in the index
-    top_k = min(model.index.ntotal, query.top_k + 1)
-
+    top_k = min(model.index.ntotal, query.top_k)
     # Embed the query and perform the search
     query_embedding = encode(query.query.text).cpu().numpy()
     top_k_scores, top_k_indicies = model.index.search(query_embedding, top_k)
 
     top_k_indicies = top_k_indicies.reshape(-1).tolist()
     top_k_scores = top_k_scores.reshape(-1).tolist()
-
     if int(query.query.uid) in top_k_indicies:
         index = top_k_indicies.index(int(query.query.uid))
         del top_k_indicies[index], top_k_scores[index]
-    else:
-        del top_k_indicies[-1], top_k_scores[-1]
 
     response = [Response(uid=uid, score=score) for uid, score in zip(top_k_indicies, top_k_scores)]
     return response

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -21,7 +21,6 @@ def _compact(input: List) -> List:
 
 # -- Setup and initialization --
 MAX_EFETCH_RETMAX = 10000
-MAX_LIST_RETMAX = 100000
 dot_env_filepath = Path(__file__).absolute().parent.parent / ".env"
 load_dotenv(dot_env_filepath)
 

--- a/semantic_search/schemas.py
+++ b/semantic_search/schemas.py
@@ -32,7 +32,7 @@ class Query(BaseModel):
                 # uids_to_docs expects a list of strings and yields a list of dictionaries. We
                 # convert the generator to a list, and then index its first element, and then
                 # unpack the dictionary and pass its contents as keyword arguments to Document.
-                normalized_docs.append(Document(**list(uids_to_docs([doc]))[0][0])) 
+                normalized_docs.append(Document(**list(uids_to_docs([doc]))[0][0]))
             else:
                 normalized_docs.append(doc)
         return normalized_docs[0] if field.name == "query" else normalized_docs

--- a/semantic_search/schemas.py
+++ b/semantic_search/schemas.py
@@ -32,7 +32,7 @@ class Query(BaseModel):
                 # uids_to_docs expects a list of strings and yields a list of dictionaries. We
                 # convert the generator to a list, and then index its first element, and then
                 # unpack the dictionary and pass its contents as keyword arguments to Document.
-                normalized_docs.append(Document(**list(uids_to_docs([doc]))[0][0]))
+                normalized_docs.append(Document(**list(uids_to_docs([doc]))[0][0])) 
             else:
                 normalized_docs.append(doc)
         return normalized_docs[0] if field.name == "query" else normalized_docs


### PR DESCRIPTION
The proposed fix for issue #69. If query id is provided then it is not displayed in the response. However, this sort of created a situation where if `top_k` is 3 and the response want's to include the query id, it won't. So essentially we are returned only 2 things instead of 3. Sort of like this:

Request:
![image](https://user-images.githubusercontent.com/57552053/112697691-81c25a00-8e5e-11eb-86cd-6cb526ea4dbc.png)

Response:
![image](https://user-images.githubusercontent.com/57552053/112697721-9141a300-8e5e-11eb-9d74-d56eb259f442.png)

If the request doesn't include the query id, it looks like this:

Request:
![image](https://user-images.githubusercontent.com/57552053/112697784-b3d3bc00-8e5e-11eb-99d6-c26347bd0b22.png)

Response:
![image](https://user-images.githubusercontent.com/57552053/112697801-bdf5ba80-8e5e-11eb-90fa-12b5c18a0e1d.png)

*Note the third uid change from 0 to 3 in the examples.