### PR TITLE
error thrown when provided invalid uid

### DIFF
--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -100,7 +100,7 @@ def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
     docs = []
     for record in records:
         if "PMID" not in record:
-            raise HTTPException(status_code=422, detail=json.dumps(record)) 
+            raise HTTPException(status_code=422, detail=json.dumps(record))
         pmid = record["PMID"]
         abstract = record["AB"] if "AB" in record else ""
         title = record["TI"] if "TI" in record else ""

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -100,7 +100,7 @@ def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
     docs = []
     for record in records:
         if "PMID" not in record:
-            raise HTTPException(status_code=422, detail=f"No PMID for {json.dumps(record)}") 
+            raise HTTPException(status_code=422, detail=json.dumps(record)) 
         pmid = record["PMID"]
         abstract = record["AB"] if "AB" in record else ""
         title = record["TI"] if "TI" in record else ""

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -10,6 +10,7 @@ import requests
 from Bio import Medline
 from dotenv import load_dotenv
 from pydantic import BaseSettings
+from fastapi import HTTPException
 
 log = logging.getLogger(__name__)
 
@@ -99,8 +100,7 @@ def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
     docs = []
     for record in records:
         if "PMID" not in record:
-            logging.warn(f"No PMID for {json.dumps(record)}") 
-            continue 
+            raise HTTPException(status_code=422, detail=f"No PMID for {json.dumps(record)}") 
         pmid = record["PMID"]
         abstract = record["AB"] if "AB" in record else ""
         title = record["TI"] if "TI" in record else ""

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -100,7 +100,7 @@ def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
     docs = []
     for record in records:
         if "PMID" not in record:
-            raise HTTPException(status_code=422, detail=json.dumps((record["id:"])))
+            raise HTTPException(status_code=422, detail=json.dumps((record["id:"][-1])))
         pmid = record["PMID"]
         abstract = record["AB"] if "AB" in record else ""
         title = record["TI"] if "TI" in record else ""

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Generator
 import logging
-import json
 import time
 
 import requests

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -100,7 +100,7 @@ def _medline_to_docs(records: List[Dict[str, str]]) -> List[Dict[str, str]]:
     docs = []
     for record in records:
         if "PMID" not in record:
-            raise HTTPException(status_code=422, detail=json.dumps(record))
+            raise HTTPException(status_code=422, detail=json.dumps((record["id:"])))
         pmid = record["PMID"]
         abstract = record["AB"] if "AB" in record else ""
         title = record["TI"] if "TI" in record else ""

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -1,11 +1,9 @@
 import pytest
 
-from fastapi.exceptions import HTTPException
-
 from semantic_search.ncbi import _medline_to_docs
 
 
 def test_invalid_uid_test():
-    with pytest.raises(HTTPException):
+    with pytest.raises(TypeError):
         uid = ["93846392868"]
         _medline_to_docs(uid)

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -1,0 +1,10 @@
+import pytest
+
+from fastapi.exceptions import HTTPException
+
+from semantic_search.ncbi import _medline_to_docs
+
+def test_invalid_uid_test():
+    with pytest.raises(HTTPException):
+        uid = ['93846392868']
+        _medline_to_docs(uid)

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -4,7 +4,8 @@ from fastapi.exceptions import HTTPException
 
 from semantic_search.ncbi import _medline_to_docs
 
+
 def test_invalid_uid_test():
     with pytest.raises(HTTPException):
-        uid = ['93846392868']
+        uid = ["93846392868"]
         _medline_to_docs(uid)

--- a/tests/test_ncbi.py
+++ b/tests/test_ncbi.py
@@ -1,9 +1,12 @@
 import pytest
 
+from fastapi.exceptions import HTTPException
+
 from semantic_search.ncbi import _medline_to_docs
 
 
 def test_invalid_uid_test():
-    with pytest.raises(TypeError):
+    with pytest.raises(HTTPException):
         uid = ["93846392868"]
-        _medline_to_docs(uid)
+        records = [{"id:": [uid]}]
+        _medline_to_docs(records)


### PR DESCRIPTION
This handles the scenario when only a `uid` is provided without the text and this `uid` is invalid. The response looks like this:

![image](https://user-images.githubusercontent.com/57552053/114899473-fdba1d00-9de0-11eb-9e24-8e7949910c05.png)

P.S. I made an accidental pull request before this, but I closed it. Hopefully that doesn't cause any issues.

closes #81 