### PR TITLE
Add release instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: CI
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![build](https://github.com/PathwayCommons/semantic-search/workflows/build/badge.svg)
-[![codecov](https://codecov.io/gh/PathwayCommons/semantic-search/branch/master/graph/badge.svg?token=K7444IQC9I)](https://codecov.io/gh/PathwayCommons/semantic-search)
+[![codecov](https://codecov.io/gh/PathwayCommons/semantic-search/branch/main/graph/badge.svg?token=K7444IQC9I)](https://codecov.io/gh/PathwayCommons/semantic-search)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 ![GitHub](https://img.shields.io/github/license/PathwayCommons/semantic-search?color=blue)
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,14 @@
+"""
+Simple check list for releasing
+
+1. Bump `version` in `setup.py`
+2. Bump the corresponding `version` in `tests/test_semantic_search.py`
+4. Commit these changes with the message: ":bookmark: Release: v<version>"
+5. Add a tag in git to mark the release: "git tag v<version> -m 'Adds tag v<version> for release' "
+   Push the tag to git: git push --tags origin main
+6. Optionally add some release notes to the tag in GitHub
+"""
+
 import setuptools
 
 with open("README.md", "r") as fh:


### PR DESCRIPTION
Adds some simple instructions to `setup.py` containing instructions for tagging and releasing. Loosley based on [this repo](https://github.com/huggingface/transformers/blob/2e5dbdf2db4599a6694d0974575a70f9bc3c978e/setup.py#L15-L57). 

Ref #33.