### PR TITLE
Fix mypy issue in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings.
         flake8 . --count --exit-zero --max-complexity=10 --statistics
-    # - name: Type check with mypy
-    #   run: |
-    #     mypy . --ignore-missing-imports --cache-dir=/dev/null
+    - name: Type check with mypy
+      run: |
+        mypy . --cache-dir=/dev/null
     - name: Test with pytest
       run: |
         pytest tests --cov ./semantic_search --cov-report=xml --cov-config=./.coveragerc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,9 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings.
         flake8 . --count --exit-zero --max-complexity=10 --statistics
-    - name: Type check with mypy
-      run: |
-        mypy . --ignore-missing-imports --cache-dir=/dev/null
+    # - name: Type check with mypy
+    #   run: |
+    #     mypy . --ignore-missing-imports --cache-dir=/dev/null
     - name: Test with pytest
       run: |
         pytest tests --cov ./semantic_search --cov-report=xml --cov-config=./.coveragerc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --statistics
     - name: Type check with mypy
       run: |
-        mypy . --cache-dir=/dev/null
+        mypy . --ignore-missing-imports --cache-dir=/dev/null
     - name: Test with pytest
       run: |
         pytest tests --cov ./semantic_search --cov-report=xml --cov-config=./.coveragerc

--- a/semantic_search/demo.py
+++ b/semantic_search/demo.py
@@ -1,7 +1,7 @@
 import json
 from typing import List
 
-import requests
+import requests  # type: ignore
 import streamlit as st
 import validators
 

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Generator
 import logging
 import time
 
-import requests
+import requests  # type: ignore
 from Bio import Medline
 from dotenv import load_dotenv
 from pydantic import BaseSettings


### PR DESCRIPTION
`mypy` is currently breaking the build because it can't find the `requests` library. No idea why this is the case, so I am electing to add `# type: ignore` after the `request` imports.