### PR TITLE
Fix codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![build](https://github.com/PathwayCommons/semantic-search/workflows/build/badge.svg)
-[![codecov](https://codecov.io/gh/PathwayCommons/semantic-search/branch/main/graph/badge.svg?token=K7444IQC9I)](https://codecov.io/gh/PathwayCommons/semantic-search)
+[![codecov](https://codecov.io/gh/PathwayCommons/semantic-search/branch/master/graph/badge.svg?token=K7444IQC9I)](https://codecov.io/gh/PathwayCommons/semantic-search)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 ![GitHub](https://img.shields.io/github/license/PathwayCommons/semantic-search?color=blue)
 


### PR DESCRIPTION
The codecov badge in the readme had a bad URL. I fixed that so up-to-date code coverage shows up in the readme again.