### PR TITLE
Typo in using loguru

### DIFF
--- a/semantic_search/main.py
+++ b/semantic_search/main.py
@@ -151,7 +151,7 @@ async def search(search: Search):
                 texts[i] = normalize_documents([str(id_)])
         except HTTPException:
             # Some bogus PMID - set text as empty string
-            logger.warn(f"Error encountered in normalize_documents: {id_}")
+            logger.warning(f"Error encountered in normalize_documents: {id_}")
             texts[i] = ""
 
     # We then embed the corresponding text and update the index

--- a/semantic_search/ncbi.py
+++ b/semantic_search/ncbi.py
@@ -124,8 +124,8 @@ def uids_to_docs(uids: List[str]) -> Generator[List[Dict[str, str]], None, None]
                 f"Retrieved docs {lower} through {upper - 1} of {num_uids - 1} in {duration}s"
             )
         except Exception as e:
-            logger.warn(f"Error encountered in uids_to_docs: {e}")
-            logger.warn(f"Bypassing docs {lower} through {upper - 1} of {num_uids - 1}")
+            logger.warning(f"Error encountered in uids_to_docs: {e}")
+            logger.warning(f"Bypassing docs {lower} through {upper - 1} of {num_uids - 1}")
             continue
         else:
             yield _medline_to_docs(eutil_response)


### PR DESCRIPTION
The loguru API has `.warning` rather than `.warn`